### PR TITLE
Fix test for required packages (Issue #14)

### DIFF
--- a/R/snotel_explorer.r
+++ b/R/snotel_explorer.r
@@ -5,14 +5,24 @@
 #' # snotel_explorer()
 
 snotel_explorer <- function(){
-  if(!requireNamespace(c("DT",
-                         "plotly",
-                         "shinydashboard",
-                         "leaflet"), quietly = TRUE)){
-    stop("Packages \"DT, plotly, shinydashboard and leaflet\" are needed 
-         for this function to work. Please install it.",
-         call. = FALSE)
-  }
+  required_pkgs <- c("DT",
+                     "plotly",
+                     "shinydashboard",
+                     "leaflet")
+  required_str <- paste0("'",
+                         paste(required_pkgs[-length(required_pkgs)], collapse = "', '"), 
+                         "', and '", 
+                         required_pkgs[length(required_pkgs)],
+                         "'")
+  a <- sapply(required_pkgs, 
+         function(x) { 
+           if(!requireNamespace(x, quietly = TRUE)) {
+             stop("Packages ", required_str, " are needed 
+                  for this function to work. Please install them.",
+                  call. = FALSE)
+           }
+         }
+  )
   
   appDir <- sprintf("%s/shiny/snotel_explorer",path.package("snotelr"))
   shiny::runApp(appDir, display.mode = "normal",launch.browser=TRUE)


### PR DESCRIPTION
Use `sapply` to loop through the list of required packages to test. Previous test only tested the first package in the list. Also quote package names separately.